### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - pypy
+
+before_install:
+  - curl -s http://snowball.tartarus.org/dist/libstemmer_c.tgz | tar xzf -
+  - pip install --use-mirrors Cython
+
+install: python setup.py install
+
+before_script: pip install --use-mirrors nose
+
+script:
+  - python runtests.py -v
+  - nosetests -v
+


### PR DESCRIPTION
This PR contains a `.travis.yml` file for use with Travis CI.

Here's a passing Travis CI build for my fork of your repo (passing for py26, py27, py32, py33, and pypy):

https://travis-ci.org/msabramo/pystemmer/builds/5022365

To set up Travis CI to run on your own repo, you just need to do a one-time setup to link Travis CI with GitHub that takes less than 2 minutes, described at http://about.travis-ci.org/docs/user/getting-started/

Then when commits are added to the GitHub repo, Travis CI will automatically run.
