### PR TITLE
Correct exit code if number of errors % 256 == 0

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -9,4 +9,4 @@ if py3k:
 else:
     num_failures, num_tests = doctest.testfile('docs/quickstart.txt')
 
-sys.exit(num_failures)
+sys.exit(1 if num_failures else 0)


### PR DESCRIPTION
For example, we had 256 errors (etc.) our process will exit with a
successful error code which is incorrect and/or misleading.