### PR TITLE
Update the hash of  libstemmer_c tarball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if 'bootstrap' in sys.argv:
     from tarballfetcher import download_and_extract_tarball
     download_and_extract_tarball(
         'http://snowball.tartarus.org/dist/libstemmer_c.tgz',
-        expected_md5='5e4c9d75c0759c4584b525cd16876ccb')
+        expected_md5='6f32f8f81cd6fa0150333ab540af5e27')
     sys.argv.remove('bootstrap')
 
 if not os.path.exists(library_dir):


### PR DESCRIPTION
Fix the bug in building:

     $ python setup.py bootstrap install
     Downloading http://snowball.tartarus.org/dist/libstemmer_c.tgz... DONE
     Checking that MD5 of libstemmer_c.tgz is 5e4c9d75c0759c4584b525cd16876ccb... MD5 is 6f32f8f81cd6fa0150333ab540af5e27.
     Incorrect MD5!