### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ python:
   - pypy
 
 before_install:
-  - pip install --use-mirrors Cython
+  - pip install Cython
 
 install: python setup.py bootstrap install
 
-before_script: pip install --use-mirrors nose
+before_script: pip install nose
 
 script:
   - python runtests.py -v


### PR DESCRIPTION
by removing deprecated `--use-mirrors` option from `pip` command in `.travis.yml`.