### PR TITLE
Update license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name = 'PyStemmer',
       description = 'Snowball stemming algorithms, for information retrieval',
       long_description = long_description,
       platforms = ["any"],
-      license = ["MIT", "BSD"],
+      license = "MIT, BSD",
       keywords = [
       "python",
       "information retrieval",


### PR DESCRIPTION
License should be a string : https://docs.python.org/3.6/distutils/setupscript.html#additional-meta-data ?

I would like to package pystemmer but I'm having trouble with `fpm` complaining about license is a list and not string.