### PR TITLE
Release 2.2.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ researchers wishing to reproduce results of earlier experiments.
 
 """.strip()
 
-version_str = '2.2.0.1'
+version_str = '2.2.0.2'
 # libstemmer_c versions have 3 components but pystemmer versions may have more
 # (so we can address a pystemmer-specific issue without having to wait for the
 # next libstemmer_c release) so take the first 3 components from version_str.


### PR DESCRIPTION
New PyPI release for Python 3.13 support (https://github.com/snowballstem/pystemmer/issues/47#issuecomment-2400536658)