### PR TITLE
Prune libstemmer_c sources from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include sampledata *
 recursive-include docs *
 include src/Stemmer.pyx src/Stemmer.c
 include benchmark.py makedist.sh MANIFEST.in runtests.py
+prune libstemmer_c-*


### PR DESCRIPTION
To avoid them getting into a sdist tarball. Hopefully fixes https://github.com/snowballstem/pystemmer/issues/50