### PR TITLE
Avoid hard-coding algorithms doctest

### DIFF
--- a/docs/quickstart.txt
+++ b/docs/quickstart.txt
@@ -9,8 +9,8 @@ First, import the library:
 
 Just for show, we'll display a list of the available stemming algorithms:
 
->>> print(Stemmer.algorithms())
-['arabic', 'armenian', 'basque', 'catalan', 'czech', 'danish', 'dutch', 'dutch_porter', 'english', 'esperanto', 'estonian', 'finnish', 'french', 'german', 'greek', 'hindi', 'hungarian', 'indonesian', 'irish', 'italian', 'lithuanian', 'nepali', 'norwegian', 'persian', 'polish', 'porter', 'portuguese', 'romanian', 'russian', 'serbian', 'sesotho', 'spanish', 'swedish', 'tamil', 'turkish', 'yiddish']
+>>> print(Stemmer.algorithms())  # doctest: +ELLIPSIS
+['arabic', ..., 'yiddish']
 
 Now, we'll get an instance of the english stemming algorithm:
 


### PR DESCRIPTION
Stemmer.algorithms() returns the list from the linked libstemmer library, so the exact set can change as libstemmer adds or removes algorithms. A quickstart doctest that hard-codes the whole list is therefore brittle even though the API behavior is still correct.

Use doctest ellipsis for the dynamic middle of the list. This keeps the example executable and still checks the shape of the output without tying the documentation to one exact libstemmer release.